### PR TITLE
Fix user_data to install git before enabling WinRM

### DIFF
--- a/terraform/modules/windows-test-domain/ec2-dc.tf
+++ b/terraform/modules/windows-test-domain/ec2-dc.tf
@@ -34,10 +34,10 @@ resource "aws_instance" "dc" {
     inline = [
       "powershell Set-ExecutionPolicy Unrestricted -Force",
       "powershell Remove-Item -Force C:\\alphagov-windows-sandbox -Recurse",
-      "git clone https://github.com/alphagov/cyber-security-windows-sandbox.git C:\\alphagov-windows-sandbox",
+      "powershell git clone https://github.com/alphagov/cyber-security-windows-sandbox.git C:\\alphagov-windows-sandbox",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\registry_system_enableula_sacl.ps1",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\registry_terminal_server_sacl.ps1",
-      "git clone https://github.com/OTRF/Set-AuditRule.git C:\\Set-AuditRule",
+      "powershell git clone https://github.com/OTRF/Set-AuditRule.git C:\\Set-AuditRule",
       "powershell C:\\Set-AuditRule\\Set-AuditRule.ps1",
       "powershell gpupdate /Force",
       "powershell Restart-Computer -Force",

--- a/terraform/modules/windows-test-domain/ec2-security-groups.tf
+++ b/terraform/modules/windows-test-domain/ec2-security-groups.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "linux" {
   ingress {
     from_port   = 22
     to_port     = 22
-    protocol    = "tcp"
+    protocol    = "TCP"
     cidr_blocks = var.ip_whitelist
   }
 
@@ -16,23 +16,23 @@ resource "aws_security_group" "linux" {
   ingress {
     from_port   = 8443
     to_port     = 8443
-    protocol    = "tcp"
+    protocol    = "TCP"
     cidr_blocks = var.ip_whitelist
   }
 
-    # Apache Spark Access
+  # Apache Spark Access
   ingress {
     from_port   = 8088
     to_port     = 8088
-    protocol    = "tcp"
+    protocol    = "TCP"
     cidr_blocks = var.ip_whitelist
   }
 
-    # Kibana Access
+  # Kibana Access
   ingress {
     from_port   = 443
     to_port     = 443
-    protocol    = "tcp"
+    protocol    = "TCP"
     cidr_blocks = var.ip_whitelist
   }
 
@@ -40,22 +40,36 @@ resource "aws_security_group" "linux" {
   ingress {
     from_port   = 7443
     to_port     = 7443
-    protocol    = "tcp"
+    protocol    = "TCP"
     cidr_blocks = var.ip_whitelist
   }
   # private subnet
   ingress {
     from_port   = 0
     to_port     = 0
-    protocol    = "-1"
+    protocol    = "ALL"
     cidr_blocks = ["172.18.39.0/24"]
   }
 
   # Connect to Internet Gateway - internet access
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "ALL"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
@@ -77,7 +91,7 @@ resource "aws_security_group" "windows" {
   ingress {
     from_port   = 5985
     to_port     = 5986
-    protocol    = "tcp"
+    protocol    = "TCP"
     cidr_blocks = var.ip_whitelist
   }
 
@@ -85,7 +99,7 @@ resource "aws_security_group" "windows" {
   ingress {
     from_port   = 443
     to_port     = 443
-    protocol    = "tcp"
+    protocol    = "TCP"
     cidr_blocks = var.ip_whitelist
   }
 
@@ -94,7 +108,7 @@ resource "aws_security_group" "windows" {
   ingress {
     from_port   = 0
     to_port     = 0
-    protocol    = "-1"
+    protocol    = "ALL"
     cidr_blocks = ["172.18.39.0/24"]
   }
 

--- a/terraform/modules/windows-test-domain/ec2-wec.tf
+++ b/terraform/modules/windows-test-domain/ec2-wec.tf
@@ -33,10 +33,10 @@ resource "aws_instance" "wec" {
     inline = [
       "powershell Set-ExecutionPolicy Unrestricted -Force",
       "powershell Remove-Item -Force C:\\alphagov-windows-sandbox -Recurse",
-      "git clone https://github.com/alphagov/cyber-security-windows-sandbox.git C:\\alphagov-windows-sandbox",
+      "powershell git clone https://github.com/alphagov/cyber-security-windows-sandbox.git C:\\alphagov-windows-sandbox",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\registry_system_enableula_sacl.ps1",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\registry_terminal_server_sacl.ps1",
-      "git clone https://github.com/OTRF/Set-AuditRule.git C:\\Set-AuditRule",
+      "powershell git clone https://github.com/OTRF/Set-AuditRule.git C:\\Set-AuditRule",
       "powershell C:\\Set-AuditRule\\Set-AuditRule.ps1",
       "powershell Restart-Computer -Force",
     ]

--- a/terraform/modules/windows-test-domain/scripts/WinRM/user_data.ps1
+++ b/terraform/modules/windows-test-domain/scripts/WinRM/user_data.ps1
@@ -1,4 +1,66 @@
 Set-Variable -Name "ProgressPreference" -Value "SilentlyContinue" -Scope global
+
+# Instal NuGet
+Install-PackageProvider -Name NuGet -RequiredVersion 2.8.5.201 -Force
+
+# Install and Enable GIT
+$git_inf_content = @"
+[Setup]
+Lang=default
+Dir=C:\Program Files\Git
+Group=Git
+NoIcons=0
+SetupType=default
+Components=ext,ext\shellhere,ext\guihere,gitlfs,assoc,autoupdate
+Tasks=
+EditorOption=VIM
+CustomEditorPath=
+PathOption=Cmd
+SSHOption=OpenSSH
+TortoiseOption=false
+CURLOption=WinSSL
+CRLFOption=LFOnly
+BashTerminalOption=ConHost
+PerformanceTweaksFSCache=Enabled
+UseCredentialManager=Enabled
+EnableSymlinks=Disabled
+EnableBuiltinInteractiveAdd=Disabled
+"@
+
+New-Item "$Tempdir\git.inf"
+Set-Content "$Tempdir\git.inf" $git_inf_content
+
+# get latest download url for git-for-windows 64-bit exe
+$git_url = "https://api.github.com/repos/git-for-windows/git/releases/latest"
+# Set TLS version to 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$asset = Invoke-RestMethod -Method Get -Uri $git_url | % assets | where name -like "*64-bit.exe"
+
+# download installer
+$installer = "$env:temp\$($asset.name)"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $installer
+
+# run installer
+$git_install_inf = "$Tempdir\git.inf"
+$install_args = "/SP- /VERYSILENT /SUPPRESSMSGBOXES /NOCANCEL /NORESTART /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /LOADINF=""$git_install_inf"""
+Start-Process -FilePath $installer -ArgumentList $install_args -Wait
+
+# add git to $PATH
+$profile_append_content = @"
+`$env:PATH += `";C:\progra~1\Git\cmd;`"
+"@
+
+Try {
+  If (Test-Path $profile) {
+    Write-Host "Profile already exists"
+  }
+} Catch {
+  New-Item $profile
+  Write-Host "Creating empty default profile"
+}
+Add-Content $profile $profile_append_content
+
 # Enable WinRM
 Write-Output "Disabling WinRM over HTTP..."
 Disable-NetFirewallRule -Name "WINRM-HTTP-In-TCP"
@@ -48,50 +110,3 @@ Start-Service WinRM
 Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -name "fDenyTSConnections" -value 0
 Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
 Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 1
-
-# Instal NuGet
-Install-PackageProvider -Name NuGet -RequiredVersion 2.8.5.201 -Force
-
-# Install and Enable GIT
-$GitInfContent = @"
-[Setup]
-Lang=default
-Dir=C:\Program Files\Git
-Group=Git
-NoIcons=0
-SetupType=default
-Components=ext,ext\shellhere,ext\guihere,gitlfs,assoc,autoupdate
-Tasks=
-EditorOption=VIM
-CustomEditorPath=
-PathOption=Cmd
-SSHOption=OpenSSH
-TortoiseOption=false
-CURLOption=WinSSL
-CRLFOption=LFOnly
-BashTerminalOption=ConHost
-PerformanceTweaksFSCache=Enabled
-UseCredentialManager=Enabled
-EnableSymlinks=Disabled
-EnableBuiltinInteractiveAdd=Disabled
-"@
-
-New-Item "$Tempdir\git.inf"
-Set-Content "$Tempdir\git.inf" $GitInfContent
-
-# get latest download url for git-for-windows 64-bit exe
-$git_url = "https://api.github.com/repos/git-for-windows/git/releases/latest"
-# Set TLS version to 1.2
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-$asset = Invoke-RestMethod -Method Get -Uri $git_url | % assets | where name -like "*64-bit.exe"
-# download installer
-$installer = "$env:temp\$($asset.name)"
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $installer
-# run installer
-$git_install_inf = "$Tempdir\git.inf"
-$install_args = "/SP- /VERYSILENT /SUPPRESSMSGBOXES /NOCANCEL /NORESTART /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /LOADINF=""$git_install_inf"""
-Start-Process -FilePath $installer -ArgumentList $install_args -Wait
-
-$env:PATH = $env:PATH += ";C:\progra~1\Git\bin"
-[System.Environment]::SetEnvironmentVariable("Path", $env:PATH, [System.EnvironmentVariableTarget]::Machine)


### PR DESCRIPTION
The user_data and remote_exec currently get kicked off at the same time. The remote exec retries until WinRM is enabled.

Previously user_data was enabling WinRM before installing git and creating the profile to add it to the path.

In this PR I've also changed how the path is set to use a powershell profile.