### PR TITLE
Generate an env vars section into EC2 user_data script

### DIFF
--- a/terraform/deployments/103495720024/outputs.tf
+++ b/terraform/deployments/103495720024/outputs.tf
@@ -7,3 +7,8 @@ output "wec_public_ip" {
   description = "The ID of the VPC"
   value       = module.windows_test_domain_module.wec_public_ip
 }
+
+output "user_data" {
+  description = "The script run on startup"
+  value       = module.windows_test_domain_module.user_data
+}

--- a/terraform/modules/windows-test-domain/locals.tf
+++ b/terraform/modules/windows-test-domain/locals.tf
@@ -15,8 +15,11 @@ locals {
   user_data_ps1    = file("${path.module}/scripts/WinRM/user_data.ps1")
   user_data        = <<END
 <powershell>
+${local.user_data_ps1}
+
 # add env vars
 $profile_set_env_vars = @"
+# setting local environment variables
 %{ for var_name, value in local.env_variables }
 `$env:${var_name} = `"${value}`"
 %{ endfor }
@@ -32,7 +35,6 @@ Try {
 }
 Add-Content $profile $profile_set_env_vars
 
-${local.user_data_ps1}
 </powershell>
 END
 }

--- a/terraform/modules/windows-test-domain/locals.tf
+++ b/terraform/modules/windows-test-domain/locals.tf
@@ -7,6 +7,32 @@ locals {
     SvcCodeURL    = "https://github.com/alphagov/cyber-security-terraform"
   }
 
-  powershell      = file("${path.module}/scripts/WinRM/user_data.ps1")
-  user_data       = "<powershell>\n${local.powershell}\n</powershell>"
+  env_variables   = {
+    "environment": var.environment
+  }
+
+
+  user_data_ps1    = file("${path.module}/scripts/WinRM/user_data.ps1")
+  user_data        = <<END
+<powershell>
+# add env vars
+$profile_set_env_vars = @"
+%{ for var_name, value in local.env_variables }
+`$env:${var_name} = `"${value}`"
+%{ endfor }
+"@
+
+Try {
+  If (Test-Path $profile) {
+    Write-Host "Profile already exists"
+  }
+} Catch {
+  New-Item $profile
+  Write-Host "Creating empty default profile"
+}
+Add-Content $profile $profile_set_env_vars
+
+${local.user_data_ps1}
+</powershell>
+END
 }

--- a/terraform/modules/windows-test-domain/outputs.tf
+++ b/terraform/modules/windows-test-domain/outputs.tf
@@ -4,6 +4,9 @@ output "dc_public_ip" {
 output "wec_public_ip" {
   value = aws_instance.wec.public_ip
 }
+output "user_data" {
+  value = local.user_data
+}
 
 
 //output "RTO_public_ip" {


### PR DESCRIPTION
Adds a map in locals.tf to setup a map of environment variables and them populates them into the powershell $profile by appending them to the user_data script. 