### PR TITLE
Change env var names to match the var names in splunk-apps

### DIFF
--- a/terraform/modules/windows-test-domain/locals.tf
+++ b/terraform/modules/windows-test-domain/locals.tf
@@ -8,12 +8,12 @@ locals {
   }
 
   env_variables = {
-    "environment" : var.environment,
-    "splunk_forwarder_name" : var.splunk_forwarder_name,
-    "splunk_config_bucket" : var.splunk_config_bucket,
-    "s3_host_account_id" : data.aws_caller_identity.current.account_id,
-    "splunk_password": random_password.splunk_admin_password.result,
-    "domain": var.domain_name
+    "ENVIRONMENT" : var.environment,
+    "FORWARDER" : var.splunk_forwarder_name,
+    "BUCKET_NAME" : var.splunk_config_bucket,
+    "AWS_ACCOUNT" : data.aws_caller_identity.current.account_id,
+    "SPLUNK_PASSWORD": random_password.splunk_admin_password.result,
+    "DOMAIN": var.domain_name
   }
 
   user_data_ps1 = file("${path.module}/scripts/WinRM/user_data.ps1")

--- a/terraform/modules/windows-test-domain/scripts/WEC/install_packages.ps1
+++ b/terraform/modules/windows-test-domain/scripts/WEC/install_packages.ps1
@@ -1,8 +1,8 @@
 #!/usr/bin/env pwsh
 
-$BUCKET_NAME=$env:splunk_config_bucket
-$FORWARDER=$env:splunk_forwarder_name
-$AWS_ACCOUNT=$env:s3_host_account_id
+$BUCKET_NAME=$env:BUCKET_NAME
+$FORWARDER=$env:FORWARDER
+$AWS_ACCOUNT=$env:AWS_ACCOUNT
 
 function Get-RoleArn {
   param([string]$forwarder, [string]$account)
@@ -80,6 +80,8 @@ Try {
 Try {
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   Read-S3Object -Credential $ROLE_SESSION -KeyPrefix packages -BucketName $BUCKET_NAME -Folder $PSScriptRoot/packages -ErrorAction Stop
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  Read-S3Object -Credential $ROLE_SESSION -KeyPrefix scripts -BucketName $BUCKET_NAME -Folder $PSScriptRoot/scripts -ErrorAction Stop
 } Catch {
   Write-Host "Failed to read S3 bucket"
   exit 1
@@ -127,7 +129,7 @@ ForEach ($package in $METADATA_CSV){
           "/i"
           "$PSScriptRoot\packages\$file"
           "AGREETOLICENSE=Yes"
-          "SPLUNKPASSWORD=$env:splunk_password"
+          "SPLUNKPASSWORD=$env:SPLUNK_PASSWORD"
           "/quiet"
           "/passive"
           "/qn"
@@ -141,4 +143,7 @@ ForEach ($package in $METADATA_CSV){
 
 Write-Host "Cleaning up"
 Remove-Item -Recurse -Force $PSScriptRoot/packages
+
+Set the env var name the get-and-update script expects
+$PSScriptRoot\scripts\get-and-update.ps1
 

--- a/terraform/modules/windows-test-domain/scripts/WinRM/templating.ps1
+++ b/terraform/modules/windows-test-domain/scripts/WinRM/templating.ps1
@@ -1,5 +1,5 @@
 $matchString = '{{domain}}'
-$replaceString = $env:domain
+$replaceString = $env:DOMAIN
 $files = Get-ChildItem -Path 'C:\alphagov-windows-sandbox\terraform\modules\windows-test-domain\scripts' -filter *.xml -Recurse
 foreach ($file in $files) {
     $matchFound = $false


### PR DESCRIPTION
(To be merged after splunk-apps change https://github.com/alphagov/cyber-security-splunk-apps/pull/646)

Change case of other env vars to all upper case for consistency
(Windows is case-insensitive about that stuff anyway)
Download the scripts folder from S3
Invoke the forwarder setup script