### PR TITLE
Add a script to generate, store and retrieve a valid EC2 ssh key

### DIFF
--- a/terraform/deployments/103495720024/module-windows-test-domain.tf
+++ b/terraform/deployments/103495720024/module-windows-test-domain.tf
@@ -2,10 +2,9 @@ module "windows_test_domain_module" {
   source          = "../../modules/windows-test-domain"
   ip_whitelist    = module.common_vars.no_third_party_cidr_list
   environment     = var.environment
-  ssh_path        = var.ssh_path
   public_key_name = var.public_key_name
-  //public_key_path         = var.public_key_path
-  //private_key_path        = var.private_key_path
+  public_key_path         = var.public_key_path
+  private_key_path        = var.private_key_path
   domain_name           = var.domain_name
   splunk_config_bucket  = var.splunk_config_bucket
   splunk_forwarder_name = var.splunk_forwarder_name

--- a/terraform/deployments/103495720024/module-windows-test-domain.tf
+++ b/terraform/deployments/103495720024/module-windows-test-domain.tf
@@ -1,11 +1,12 @@
 module "windows_test_domain_module" {
-  source                  = "../../modules/windows-test-domain"
-  ip_whitelist            = module.common_vars.no_third_party_cidr_list
-  environment             = var.environment
-  public_key_name         = var.public_key_name
-  public_key_path         = var.public_key_path
-  private_key_path        = var.private_key_path
-  domain_name             = var.domain_name
-  splunk_config_bucket    = var.splunk_config_bucket
-  splunk_forwarder_name   = var.splunk_forwarder_name
+  source          = "../../modules/windows-test-domain"
+  ip_whitelist    = module.common_vars.no_third_party_cidr_list
+  environment     = var.environment
+  ssh_path        = var.ssh_path
+  public_key_name = var.public_key_name
+  //public_key_path         = var.public_key_path
+  //private_key_path        = var.private_key_path
+  domain_name           = var.domain_name
+  splunk_config_bucket  = var.splunk_config_bucket
+  splunk_forwarder_name = var.splunk_forwarder_name
 }

--- a/terraform/deployments/103495720024/outputs.tf
+++ b/terraform/deployments/103495720024/outputs.tf
@@ -7,3 +7,13 @@ output "wec_public_ip" {
   description = "The ID of the VPC"
   value       = module.windows_test_domain_module.wec_public_ip
 }
+
+output "private_key_file" {
+  description = "The path to the generated private key file"
+  value       = module.windows_test_domain_module.private_key_file
+}
+
+output "public_key_file" {
+  description = "The path to the generated public key file"
+  value       = module.windows_test_domain_module.public_key_file
+}

--- a/terraform/deployments/103495720024/outputs.tf
+++ b/terraform/deployments/103495720024/outputs.tf
@@ -7,13 +7,3 @@ output "wec_public_ip" {
   description = "The ID of the VPC"
   value       = module.windows_test_domain_module.wec_public_ip
 }
-
-output "private_key_file" {
-  description = "The path to the generated private key file"
-  value       = module.windows_test_domain_module.private_key_file
-}
-
-output "public_key_file" {
-  description = "The path to the generated public key file"
-  value       = module.windows_test_domain_module.public_key_file
-}

--- a/terraform/deployments/103495720024/variables.tf
+++ b/terraform/deployments/103495720024/variables.tf
@@ -10,29 +10,22 @@ variable "environment" {
   default     = "staging"
 }
 
-variable "ssh_path" {
-  description = "Directory to create ssh key into"
-  default     = "~/.ssh"
-}
-
 variable "public_key_name" {
   description = "A name for AWS Keypair to use to auth to helk. Can be anything you specify."
   default     = "windows_sandbox_ssh_key"
 }
 
-/*
 variable "public_key_path" {
   description = "Path to the public key to be loaded into the helk authorized_keys file"
   type        = string
-  default     = "~/.ssh/test-1.pub"
+  default     = "~/.ssh/windows_sandbox_ssh_key.pub"
 }
 
 variable "private_key_path" {
   description = "Path to the private key to use to authenticate to helk."
   type        = string
-  default     = "~/.ssh/test-1"
+  default     = "~/.ssh/windows_sandbox_ssh_key"
 }
-*/
 
 variable "domain_name" {
   description = ""

--- a/terraform/deployments/103495720024/variables.tf
+++ b/terraform/deployments/103495720024/variables.tf
@@ -10,11 +10,17 @@ variable "environment" {
   default     = "staging"
 }
 
+variable "ssh_path" {
+  description = "Directory to create ssh key into"
+  default     = "~/.ssh"
+}
+
 variable "public_key_name" {
   description = "A name for AWS Keypair to use to auth to helk. Can be anything you specify."
   default     = "windows_sandbox_ssh_key"
 }
 
+/*
 variable "public_key_path" {
   description = "Path to the public key to be loaded into the helk authorized_keys file"
   type        = string
@@ -26,6 +32,7 @@ variable "private_key_path" {
   type        = string
   default     = "~/.ssh/test-1"
 }
+*/
 
 variable "domain_name" {
   description = ""

--- a/terraform/deployments/103495720024/variables.tf
+++ b/terraform/deployments/103495720024/variables.tf
@@ -12,7 +12,7 @@ variable "environment" {
 
 variable "public_key_name" {
   description = "A name for AWS Keypair to use to auth to helk. Can be anything you specify."
-  default     = "win-test-ssh"
+  default     = "windows_sandbox_ssh_key"
 }
 
 variable "public_key_path" {

--- a/terraform/modules/windows-test-domain/data.tf
+++ b/terraform/modules/windows-test-domain/data.tf
@@ -7,7 +7,7 @@ data "aws_region" "current" {}
 data "aws_ami" "windows_server_2016_base" {
   owners = ["amazon"]
   filter {
-    name = "name"
+    name   = "name"
     values = ["Windows_Server-2016-English-Core-Base-2021.04.14"]
   }
 }

--- a/terraform/modules/windows-test-domain/ec2-dc.tf
+++ b/terraform/modules/windows-test-domain/ec2-dc.tf
@@ -4,7 +4,6 @@ This process is going to provision from a Pre-Built AMI.
 This AMI already has the forest, GPOs, and Users deployed.
 */
 resource "aws_instance" "dc" {
-  depends_on    = [null_resource.ssh_create_keypair]
   instance_type = "t2.medium"
   ami           = data.aws_ami.windows_server_2016_base.image_id
 
@@ -26,7 +25,7 @@ resource "aws_instance" "dc" {
       host     = coalesce(self.public_ip, self.private_ip)
       type     = "winrm"
       user     = "Administrator"
-      password = rsadecrypt(self.password_data, lookup(local.keypair, "private"))
+      password = rsadecrypt(self.password_data, file(var.private_key_path))
       https    = true
       insecure = true
       port     = 5986
@@ -54,7 +53,7 @@ resource "null_resource" "dc_rename" {
       host     = coalesce(aws_instance.dc.public_ip, aws_instance.dc.private_ip)
       type     = "winrm"
       user     = "Administrator"
-      password = rsadecrypt(aws_instance.dc.password_data, lookup(local.keypair, "private"))
+      password = rsadecrypt(aws_instance.dc.password_data, file(var.private_key_path))
       https    = true
       insecure = true
       port     = 5986
@@ -76,7 +75,7 @@ resource "null_resource" "dc_deploy_forest" {
       host     = coalesce(aws_instance.dc.public_ip, aws_instance.dc.private_ip)
       type     = "winrm"
       user     = "Administrator"
-      password = rsadecrypt(aws_instance.dc.password_data, lookup(local.keypair, "private"))
+      password = rsadecrypt(aws_instance.dc.password_data, file(var.private_key_path))
       https    = true
       insecure = true
       port     = 5986
@@ -98,7 +97,7 @@ resource "null_resource" "dc_setup_domain" {
       host     = coalesce(aws_instance.dc.public_ip, aws_instance.dc.private_ip)
       type     = "winrm"
       user     = "Administrator"
-      password = rsadecrypt(aws_instance.dc.password_data, lookup(local.keypair, "private"))
+      password = rsadecrypt(aws_instance.dc.password_data, file(var.private_key_path))
       https    = true
       insecure = true
       port     = 5986

--- a/terraform/modules/windows-test-domain/ec2-dc.tf
+++ b/terraform/modules/windows-test-domain/ec2-dc.tf
@@ -4,8 +4,9 @@ This process is going to provision from a Pre-Built AMI.
 This AMI already has the forest, GPOs, and Users deployed.
 */
 resource "aws_instance" "dc" {
+  depends_on    = [null_resource.ssh_create_keypair]
   instance_type = "t2.medium"
-  ami = data.aws_ami.windows_server_2016_base.image_id
+  ami           = data.aws_ami.windows_server_2016_base.image_id
 
   tags = merge(local.tags, {
     Name = "WSDC01.${var.domain_name}"
@@ -15,20 +16,20 @@ resource "aws_instance" "dc" {
   vpc_security_group_ids = [aws_security_group.windows.id]
   private_ip             = local.dc_private_ip
 
-  key_name               = aws_key_pair.auth.key_name
-  get_password_data      = true
+  key_name          = aws_key_pair.auth.key_name
+  get_password_data = true
 
   user_data = local.user_data
 
   provisioner "remote-exec" {
     connection {
-      host        = coalesce(self.public_ip, self.private_ip)
-      type        = "winrm"
-      user        = "Administrator"
-      password    = rsadecrypt(self.password_data,file(var.private_key_path))
-      https       = true
-      insecure    = true
-      port        = 5986
+      host     = coalesce(self.public_ip, self.private_ip)
+      type     = "winrm"
+      user     = "Administrator"
+      password = rsadecrypt(self.password_data, lookup(local.keypair, "private"))
+      https    = true
+      insecure = true
+      port     = 5986
 
     }
     inline = [
@@ -50,13 +51,13 @@ resource "aws_instance" "dc" {
 resource "null_resource" "dc_rename" {
   provisioner "remote-exec" {
     connection {
-      host        = coalesce(aws_instance.dc.public_ip, aws_instance.dc.private_ip)
-      type        = "winrm"
-      user        = "Administrator"
-      password    = rsadecrypt(aws_instance.dc.password_data,file(var.private_key_path))
-      https       = true
-      insecure    = true
-      port        = 5986
+      host     = coalesce(aws_instance.dc.public_ip, aws_instance.dc.private_ip)
+      type     = "winrm"
+      user     = "Administrator"
+      password = rsadecrypt(aws_instance.dc.password_data, lookup(local.keypair, "private"))
+      https    = true
+      insecure = true
+      port     = 5986
 
     }
     inline = [
@@ -72,13 +73,13 @@ resource "null_resource" "dc_deploy_forest" {
   depends_on = [null_resource.dc_rename]
   provisioner "remote-exec" {
     connection {
-      host        = coalesce(aws_instance.dc.public_ip, aws_instance.dc.private_ip)
-      type        = "winrm"
-      user        = "Administrator"
-      password    = rsadecrypt(aws_instance.dc.password_data,file(var.private_key_path))
-      https       = true
-      insecure    = true
-      port        = 5986
+      host     = coalesce(aws_instance.dc.public_ip, aws_instance.dc.private_ip)
+      type     = "winrm"
+      user     = "Administrator"
+      password = rsadecrypt(aws_instance.dc.password_data, lookup(local.keypair, "private"))
+      https    = true
+      insecure = true
+      port     = 5986
 
     }
     inline = [
@@ -94,13 +95,13 @@ resource "null_resource" "dc_setup_domain" {
   depends_on = [null_resource.dc_deploy_forest]
   provisioner "remote-exec" {
     connection {
-      host        = coalesce(aws_instance.dc.public_ip, aws_instance.dc.private_ip)
-      type        = "winrm"
-      user        = "Administrator"
-      password    = rsadecrypt(aws_instance.dc.password_data,file(var.private_key_path))
-      https       = true
-      insecure    = true
-      port        = 5986
+      host     = coalesce(aws_instance.dc.public_ip, aws_instance.dc.private_ip)
+      type     = "winrm"
+      user     = "Administrator"
+      password = rsadecrypt(aws_instance.dc.password_data, lookup(local.keypair, "private"))
+      https    = true
+      insecure = true
+      port     = 5986
 
     }
     inline = [

--- a/terraform/modules/windows-test-domain/ec2-keypair.tf
+++ b/terraform/modules/windows-test-domain/ec2-keypair.tf
@@ -1,9 +1,9 @@
-resource "aws_secretsmanager_secret" "ssh_keypair" {
-  name       = var.public_key_name
+data "aws_secretsmanager_secret" "ssh_keypair" {
+  name = var.public_key_name
 }
 
 resource "aws_secretsmanager_secret_version" "ssh_keypair" {
-  secret_id     = aws_secretsmanager_secret.ssh_keypair.id
+  secret_id     = data.aws_secretsmanager_secret.ssh_keypair.id
   secret_string = jsonencode({
     private = file(var.private_key_path)
     public  = file(var.public_key_path)

--- a/terraform/modules/windows-test-domain/ec2-keypair.tf
+++ b/terraform/modules/windows-test-domain/ec2-keypair.tf
@@ -1,3 +1,10 @@
+resource "null_resource" "ssh-keypair" {
+  provisioner "local-exec" {
+    command = "${path.module}/scripts/Local/create_keypair.sh ${var.ssh_path} ${var.public_key_name}"
+    interpreter = ["bash"]
+  }
+}
+
 resource "aws_key_pair" "auth" {
   key_name   = "winssh"
   public_key = file(var.public_key_path)

--- a/terraform/modules/windows-test-domain/ec2-keypair.tf
+++ b/terraform/modules/windows-test-domain/ec2-keypair.tf
@@ -1,11 +1,27 @@
-resource "null_resource" "ssh-keypair" {
+resource "null_resource" "ssh_create_keypair" {
   provisioner "local-exec" {
-    command = "${path.module}/scripts/Local/create_keypair.sh ${var.ssh_path} ${var.public_key_name}"
+    command     = "${path.module}/scripts/Local/create_keypair.sh ${var.ssh_path} ${var.public_key_name}"
     interpreter = ["bash"]
   }
 }
 
+locals {
+  keypair = {
+    private = file("${var.ssh_path}/${var.public_key_name}")
+    public  = file("${var.ssh_path}/${var.public_key_name}.pub")
+  }
+}
+
+resource "aws_secretsmanager_secret" "ssh_keypair" {
+  name = var.public_key_name
+}
+
+resource "aws_secretsmanager_secret_version" "example" {
+  secret_id     = aws_secretsmanager_secret.ssh_keypair.id
+  secret_string = jsonencode(local.keypair)
+}
+
 resource "aws_key_pair" "auth" {
-  key_name   = "winssh"
-  public_key = file(var.public_key_path)
+  key_name   = var.public_key_name
+  public_key = lookup(local.keypair, "public")
 }

--- a/terraform/modules/windows-test-domain/ec2-keypair.tf
+++ b/terraform/modules/windows-test-domain/ec2-keypair.tf
@@ -1,27 +1,16 @@
-resource "null_resource" "ssh_create_keypair" {
-  provisioner "local-exec" {
-    command     = "${path.module}/scripts/Local/create_keypair.sh ${var.ssh_path} ${var.public_key_name}"
-    interpreter = ["bash"]
-  }
-}
-
-locals {
-  keypair = {
-    private = file("${var.ssh_path}/${var.public_key_name}")
-    public  = file("${var.ssh_path}/${var.public_key_name}.pub")
-  }
-}
-
 resource "aws_secretsmanager_secret" "ssh_keypair" {
-  name = var.public_key_name
+  name       = var.public_key_name
 }
 
-resource "aws_secretsmanager_secret_version" "example" {
+resource "aws_secretsmanager_secret_version" "ssh_keypair" {
   secret_id     = aws_secretsmanager_secret.ssh_keypair.id
-  secret_string = jsonencode(local.keypair)
+  secret_string = jsonencode({
+    private = file(var.private_key_path)
+    public  = file(var.public_key_path)
+  })
 }
 
 resource "aws_key_pair" "auth" {
   key_name   = var.public_key_name
-  public_key = lookup(local.keypair, "public")
+  public_key = file(var.public_key_path)
 }

--- a/terraform/modules/windows-test-domain/ec2-security-groups.tf
+++ b/terraform/modules/windows-test-domain/ec2-security-groups.tf
@@ -2,7 +2,7 @@
 resource "aws_security_group" "linux" {
   name        = "linux_security_group"
   description = "Mordor: Security Group for the Linux Hosts"
-  vpc_id	= aws_vpc.default.id
+  vpc_id      = aws_vpc.default.id
 
   # SSH Access
   ingress {

--- a/terraform/modules/windows-test-domain/ec2-wec.tf
+++ b/terraform/modules/windows-test-domain/ec2-wec.tf
@@ -4,7 +4,7 @@ This process is going to provision from a Pre-Built AMI.
 This AMI already has the WEC subscriptions and WEC service deployed.
 */
 resource "aws_instance" "wec" {
-  depends_on    = [null_resource.ssh_create_keypair, null_resource.dc_setup_domain]
+  depends_on    = [null_resource.dc_setup_domain]
   instance_type = "t2.large"
   ami           = data.aws_ami.windows_server_2016_base.image_id
 
@@ -28,7 +28,7 @@ resource "aws_instance" "wec" {
       host     = coalesce(self.public_ip, self.private_ip)
       type     = "winrm"
       user     = "Administrator"
-      password = rsadecrypt(self.password_data, lookup(local.keypair, "private"))
+      password = rsadecrypt(self.password_data, file(var.private_key_path))
       https    = true
       insecure = true
       port     = 5986
@@ -59,7 +59,7 @@ resource "null_resource" "wec_rename" {
       host     = coalesce(aws_instance.wec.public_ip, aws_instance.wec.private_ip)
       type     = "winrm"
       user     = "Administrator"
-      password = rsadecrypt(aws_instance.wec.password_data, lookup(local.keypair, "private"))
+      password = rsadecrypt(aws_instance.wec.password_data, file(var.private_key_path))
       https    = true
       insecure = true
       port     = 5986
@@ -81,7 +81,7 @@ resource "null_resource" "wec_join_domain" {
       host     = coalesce(aws_instance.wec.public_ip, aws_instance.wec.private_ip)
       type     = "winrm"
       user     = "Administrator"
-      password = rsadecrypt(aws_instance.wec.password_data, lookup(local.keypair, "private"))
+      password = rsadecrypt(aws_instance.wec.password_data, file(var.private_key_path))
       https    = true
       insecure = true
       port     = 5986
@@ -104,7 +104,7 @@ resource "null_resource" "wec_configure" {
       host     = coalesce(aws_instance.wec.public_ip, aws_instance.wec.private_ip)
       type     = "winrm"
       user     = "Administrator"
-      password = rsadecrypt(aws_instance.wec.password_data, lookup(local.keypair, "private"))
+      password = rsadecrypt(aws_instance.wec.password_data, file(var.private_key_path))
       https    = true
       insecure = true
       port     = 5986
@@ -126,7 +126,7 @@ resource "null_resource" "wec_forward_to_splunk" {
       host     = coalesce(aws_instance.wec.public_ip, aws_instance.wec.private_ip)
       type     = "winrm"
       user     = "Administrator"
-      password = rsadecrypt(aws_instance.wec.password_data, lookup(local.keypair, "private"))
+      password = rsadecrypt(aws_instance.wec.password_data, file(var.private_key_path))
       https    = true
       insecure = true
       port     = 5986

--- a/terraform/modules/windows-test-domain/ec2-workstations.tf
+++ b/terraform/modules/windows-test-domain/ec2-workstations.tf
@@ -4,7 +4,7 @@ This process is going to provision from a Pre-Built AMI.
 These AMI's already has been domain joined prior to this process
 
 */
- # ACCT001 Build
+# ACCT001 Build
 //resource "aws_instance" "acct001" {
 //  instance_type = "t2.medium"
 //  ami = coalesce(data.aws_ami.windows_10.image_id)
@@ -49,7 +49,7 @@ These AMI's already has been domain joined prior to this process
 //}
 
 
- # HR001 Build
+# HR001 Build
 //resource "aws_instance" "hr001" {
 //  instance_type = "t2.medium"
 //  ami = coalesce(data.aws_ami.windows_10.image_id)
@@ -92,7 +92,7 @@ These AMI's already has been domain joined prior to this process
 //}
 
 
- # IT001 Build
+# IT001 Build
 //resource "aws_instance" "it001" {
 //  instance_type = "t2.medium"
 //  ami = coalesce(data.aws_ami.windows_10.image_id)

--- a/terraform/modules/windows-test-domain/locals.tf
+++ b/terraform/modules/windows-test-domain/locals.tf
@@ -7,7 +7,7 @@ locals {
     SvcCodeURL    = "https://github.com/alphagov/cyber-security-windows-sandbox"
   }
 
-  dc_private_ip = "172.18.39.5"
+  dc_private_ip  = "172.18.39.5"
   wec_private_ip = "172.18.39.102"
 
   env_variables = {
@@ -15,10 +15,10 @@ locals {
     "FORWARDER" : var.splunk_forwarder_name,
     "BUCKET_NAME" : var.splunk_config_bucket,
     "AWS_ACCOUNT" : data.aws_caller_identity.current.account_id,
-    "SPLUNK_PASSWORD": random_password.splunk_admin_password.result,
-    "DOMAIN_PASSWORD": random_password.domain_admin_password.result,
-    "DOMAIN": var.domain_name
-    "DOMAIN_CONTROLLER_IP": local.dc_private_ip
+    "SPLUNK_PASSWORD" : random_password.splunk_admin_password.result,
+    "DOMAIN_PASSWORD" : random_password.domain_admin_password.result,
+    "DOMAIN" : var.domain_name
+    "DOMAIN_CONTROLLER_IP" : local.dc_private_ip
   }
 
   user_data_ps1 = file("${path.module}/scripts/WinRM/user_data.ps1")

--- a/terraform/modules/windows-test-domain/outputs.tf
+++ b/terraform/modules/windows-test-domain/outputs.tf
@@ -7,7 +7,12 @@ output "wec_public_ip" {
 output "user_data" {
   value = local.user_data
 }
-
+output "private_key_file" {
+  value = "${var.ssh_path}/${var.public_key_name}"
+}
+output "public_key_file" {
+  value = "${var.ssh_path}/${var.public_key_name}.pub"
+}
 
 //output "RTO_public_ip" {
 //  value = aws_instance.rto.public_ip

--- a/terraform/modules/windows-test-domain/outputs.tf
+++ b/terraform/modules/windows-test-domain/outputs.tf
@@ -7,12 +7,6 @@ output "wec_public_ip" {
 output "user_data" {
   value = local.user_data
 }
-output "private_key_file" {
-  value = "${var.ssh_path}/${var.public_key_name}"
-}
-output "public_key_file" {
-  value = "${var.ssh_path}/${var.public_key_name}.pub"
-}
 
 //output "RTO_public_ip" {
 //  value = aws_instance.rto.public_ip

--- a/terraform/modules/windows-test-domain/scripts/Local/create_keypair.sh
+++ b/terraform/modules/windows-test-domain/scripts/Local/create_keypair.sh
@@ -12,4 +12,5 @@ else
   openssl genrsa -out $private 2048
   chmod 400 $private
   ssh-keygen -y -f $private > $public
+  echo $private
 fi

--- a/terraform/modules/windows-test-domain/scripts/Local/create_keypair.sh
+++ b/terraform/modules/windows-test-domain/scripts/Local/create_keypair.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+if [[ $# -lt 2 ]]; then
+  echo "Usage: create_keypair.sh directory keypair_name"
+else
+  FOLDER=$1
+  KEYPAIR_NAME=$2
+  mkdir -p $FOLDER
+  private="${FOLDER}/${KEYPAIR_NAME}"
+  public="${private}.pub"
+  mv $private "${private}.old"
+  mv $public "${public}.old"
+  openssl genrsa -out $private 2048
+  chmod 400 $private
+  ssh-keygen -y -f $private > $public
+fi

--- a/terraform/modules/windows-test-domain/scripts/Local/retrieve_keypair.sh
+++ b/terraform/modules/windows-test-domain/scripts/Local/retrieve_keypair.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+FOLDER=$1
+KEYPAIR_NAME=$2
+mkdir -p $FOLDER
+private="${FOLDER}/${KEYPAIR_NAME}"
+public="${private}.pub"
+mv $private "${private}.old"
+mv $public "${public}.old"
+secret=$(aws secretsmanager get-secret-value --secret-id=$KEYPAIR_NAME)
+secret_value=$(echo $secret | jq -r .SecretString)
+private_key=$(echo $secret_value | jq -r .private)
+public_key=$(echo $secret_value | jq -r .public)
+echo $private_key > $private
+echo $public_key > $public
+echo $public
+cat $public

--- a/terraform/modules/windows-test-domain/ssm.tf
+++ b/terraform/modules/windows-test-domain/ssm.tf
@@ -2,18 +2,18 @@ resource "aws_ssm_parameter" "windows_dc_admin_password" {
   name        = "/windows-sandbox/dc/administrator/password"
   description = "Password for local windows DC Administrator"
   type        = "SecureString"
-  value       = try(rsadecrypt(aws_instance.dc.password_data,file(var.private_key_path)), "missing")
+  value       = try(rsadecrypt(aws_instance.dc.password_data, file(var.private_key_path)), "missing")
   overwrite   = true
-  tags = merge(local.tags, { "Name" : "/windows-sandbox/administrator/password" })
+  tags        = merge(local.tags, { "Name" : "/windows-sandbox/administrator/password" })
 }
 
 resource "aws_ssm_parameter" "windows_wec_admin_password" {
   name        = "/windows-sandbox/wec/administrator/password"
   description = "Password for local windows WEC Administrator"
   type        = "SecureString"
-  value       = try(rsadecrypt(aws_instance.wec.password_data,file(var.private_key_path)), "missing")
+  value       = try(rsadecrypt(aws_instance.wec.password_data, file(var.private_key_path)), "missing")
   overwrite   = true
-  tags = merge(local.tags, { "Name" : "/windows-sandbox/administrator/password" })
+  tags        = merge(local.tags, { "Name" : "/windows-sandbox/administrator/password" })
 }
 
 resource "random_password" "splunk_admin_password" {
@@ -28,7 +28,7 @@ resource "aws_ssm_parameter" "windows_wec_splunk_password" {
   type        = "SecureString"
   value       = random_password.splunk_admin_password.result
   overwrite   = true
-  tags = merge(local.tags, { "Name" : "/windows-sandbox/wec/splunk/password" })
+  tags        = merge(local.tags, { "Name" : "/windows-sandbox/wec/splunk/password" })
 }
 
 resource "random_password" "domain_admin_password" {
@@ -43,5 +43,5 @@ resource "aws_ssm_parameter" "windows_domain_admin_password" {
   type        = "SecureString"
   value       = random_password.domain_admin_password.result
   overwrite   = true
-  tags = merge(local.tags, { "Name" : "/windows-sandbox/domain/admin/password" })
+  tags        = merge(local.tags, { "Name" : "/windows-sandbox/domain/admin/password" })
 }

--- a/terraform/modules/windows-test-domain/ssm.tf
+++ b/terraform/modules/windows-test-domain/ssm.tf
@@ -2,7 +2,7 @@ resource "aws_ssm_parameter" "windows_dc_admin_password" {
   name        = "/windows-sandbox/dc/administrator/password"
   description = "Password for local windows DC Administrator"
   type        = "SecureString"
-  value       = try(rsadecrypt(aws_instance.dc.password_data, lookup(local.keypair, "private")), "missing")
+  value       = try(rsadecrypt(aws_instance.dc.password_data, file(var.private_key_path)), "missing")
   overwrite   = true
   tags        = merge(local.tags, { "Name" : "/windows-sandbox/administrator/password" })
 }
@@ -11,7 +11,7 @@ resource "aws_ssm_parameter" "windows_wec_admin_password" {
   name        = "/windows-sandbox/wec/administrator/password"
   description = "Password for local windows WEC Administrator"
   type        = "SecureString"
-  value       = try(rsadecrypt(aws_instance.wec.password_data, lookup(local.keypair, "private")), "missing")
+  value       = try(rsadecrypt(aws_instance.wec.password_data, file(var.private_key_path)), "missing")
   overwrite   = true
   tags        = merge(local.tags, { "Name" : "/windows-sandbox/administrator/password" })
 }

--- a/terraform/modules/windows-test-domain/ssm.tf
+++ b/terraform/modules/windows-test-domain/ssm.tf
@@ -2,7 +2,7 @@ resource "aws_ssm_parameter" "windows_dc_admin_password" {
   name        = "/windows-sandbox/dc/administrator/password"
   description = "Password for local windows DC Administrator"
   type        = "SecureString"
-  value       = try(rsadecrypt(aws_instance.dc.password_data, file(var.private_key_path)), "missing")
+  value       = try(rsadecrypt(aws_instance.dc.password_data, lookup(local.keypair, "private")), "missing")
   overwrite   = true
   tags        = merge(local.tags, { "Name" : "/windows-sandbox/administrator/password" })
 }
@@ -11,7 +11,7 @@ resource "aws_ssm_parameter" "windows_wec_admin_password" {
   name        = "/windows-sandbox/wec/administrator/password"
   description = "Password for local windows WEC Administrator"
   type        = "SecureString"
-  value       = try(rsadecrypt(aws_instance.wec.password_data, file(var.private_key_path)), "missing")
+  value       = try(rsadecrypt(aws_instance.wec.password_data, lookup(local.keypair, "private")), "missing")
   overwrite   = true
   tags        = merge(local.tags, { "Name" : "/windows-sandbox/administrator/password" })
 }

--- a/terraform/modules/windows-test-domain/variables.tf
+++ b/terraform/modules/windows-test-domain/variables.tf
@@ -18,9 +18,15 @@ variable "environment" {
 //  default     = "~/.aws/credentials"
 //}
 //
+
+variable "ssh_path" {
+  description = "Directory to create ssh key into"
+  default     = "~/.ssh"
+}
+
 variable "public_key_name" {
   description = "A name for AWS Keypair to use to auth to helk. Can be anything you specify."
-  default     = "linux"
+  default     = "windows_sandbox_ssh_key"
 }
 
 variable "public_key_path" {

--- a/terraform/modules/windows-test-domain/variables.tf
+++ b/terraform/modules/windows-test-domain/variables.tf
@@ -3,32 +3,11 @@ variable "environment" {
   description = "One of [ production | staging | demo ]"
 }
 
-//variable "profile" {
-//  default = "terraform"
-//}
-
-//variable "availability_zone" {
-//  description = "https://www.terraform.io/docs/providers/aws/d/availability_zone.html"
-//  default     = ""
-//}
-
-//variable "shared_credentials_file" {
-//  description = "Path to your AWS credentials file"
-//  type        = string
-//  default     = "~/.aws/credentials"
-//}
-//
-
-variable "ssh_path" {
-  description = "Directory to create ssh key into"
-  default     = "~/.ssh"
-}
-
 variable "public_key_name" {
   description = "A name for AWS Keypair to use to auth to helk. Can be anything you specify."
   default     = "windows_sandbox_ssh_key"
 }
-/*
+
 variable "public_key_path" {
   description = "Path to the public key to be loaded into the helk authorized_keys file"
   type        = string
@@ -40,7 +19,7 @@ variable "private_key_path" {
   type        = string
   default     = "~/.ssh/linux"
 }
-*/
+
 variable "domain_name" {
   description = ""
   type        = string

--- a/terraform/modules/windows-test-domain/variables.tf
+++ b/terraform/modules/windows-test-domain/variables.tf
@@ -28,7 +28,7 @@ variable "public_key_name" {
   description = "A name for AWS Keypair to use to auth to helk. Can be anything you specify."
   default     = "windows_sandbox_ssh_key"
 }
-
+/*
 variable "public_key_path" {
   description = "Path to the public key to be loaded into the helk authorized_keys file"
   type        = string
@@ -40,7 +40,7 @@ variable "private_key_path" {
   type        = string
   default     = "~/.ssh/linux"
 }
-
+*/
 variable "domain_name" {
   description = ""
   type        = string

--- a/terraform/modules/windows-test-domain/vpc.tf
+++ b/terraform/modules/windows-test-domain/vpc.tf
@@ -29,7 +29,7 @@ resource "aws_vpc_dhcp_options" "default" {
   domain_name          = var.domain_name
   domain_name_servers  = concat([aws_instance.dc.private_ip], var.external_dns_servers)
   netbios_name_servers = [aws_instance.dc.private_ip]
- }
+}
 
 resource "aws_vpc_dhcp_options_association" "default" {
   vpc_id          = aws_vpc.default.id


### PR DESCRIPTION
- [x] Add create_keypair.sh script
- [x] Add retrieve_keypair.sh script
- [ ] ~Run in local exec~  
  (I decided not to do this because I couldn't get the `depends_on` to work properly so I've just put it in the pipeline)
- [x] Store keypair in secretsmanager as version of existing secret
   (Secrets manager does not handle destroy/apply well) 
- [x] Test apply with the generated key
- [x] Test destroy with the retrieved key
- [x] Add an issue to manage the secret in the exec_roles terraform     