### PR TITLE
Add secretsmanager secret for SSH key to exec_roles terraform

### DIFF
--- a/terraform/deployments/103495720024_exec_roles/secretsmanager.tf
+++ b/terraform/deployments/103495720024_exec_roles/secretsmanager.tf
@@ -1,0 +1,3 @@
+resource "aws_secretsmanager_secret" "ssh_key" {
+  name = var.ssh_key_name
+}

--- a/terraform/deployments/103495720024_exec_roles/variables.tf
+++ b/terraform/deployments/103495720024_exec_roles/variables.tf
@@ -15,3 +15,8 @@ variable "splunk_forwarder_name" {
   type        = string
   default     = "co-cdio-technology-official-it-platform-wec"
 }
+
+variable "ssh_key_name" {
+  description = "A name for AWS Keypair to use to auth to helk. Can be anything you specify."
+  default     = "windows_sandbox_ssh_key"
+}


### PR DESCRIPTION
This terraform is applied and updated.
The sandbox terraform is repeatedly applied and destroyed which doesn't work with secretsmanager secrets because they get scheduled for deletion rather than deleted.