### PR TITLE
Add a script to generate some known events on the WEC and DC instances 

### DIFF
--- a/terraform/modules/windows-test-domain/ec2-dc.tf
+++ b/terraform/modules/windows-test-domain/ec2-dc.tf
@@ -110,6 +110,7 @@ resource "null_resource" "dc_setup_domain" {
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\DC\\add_ou.ps1",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\DC\\import_users.ps1",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WinRM\\set_dns_resolvers.ps1",
+      "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\DC\\generate_events.ps1",
       "powershell C:\\Set-AuditRule\\Set-AuditRule.ps1",
       "powershell gpupdate /Force",
       "powershell Restart-Computer -Force",

--- a/terraform/modules/windows-test-domain/ec2-wec.tf
+++ b/terraform/modules/windows-test-domain/ec2-wec.tf
@@ -39,6 +39,7 @@ resource "aws_instance" "wec" {
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\registry_system_enableula_sacl.ps1",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\registry_terminal_server_sacl.ps1",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WinRM\\set_dns_resolvers.ps1",
+      "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\generate_events.ps1",
       "powershell Restart-Computer -Force"
     ]
 

--- a/terraform/modules/windows-test-domain/scripts/DC/generate_events.ps1
+++ b/terraform/modules/windows-test-domain/scripts/DC/generate_events.ps1
@@ -1,0 +1,13 @@
+# Set up new source for application log
+New-EventLog -Source DCTestApplicationSource -LogName Application
+# Send a test event through
+Write-EventLog -LogName "Application" -Source DCTestApplicationSource   -EventID 3001 -EntryType Information -Message "This is a test message"
+# Check test event has been sent
+Get-WinEvent -FilterHashtable @{logname='Application'; ID = 3001} | Where-Object  { $_.Message -Match "This is a test message"}
+
+# Set up new source for system log
+New-EventLog -Source DCTestSystemSource -LogName System
+# Send a test event through
+Write-EventLog -LogName "System" -Source DCTestSystemSource -EventID 3001 -EntryType Information -Message "This is a test message"
+# Check test event has been sent
+Get-WinEvent -FilterHashtable @{logname='System'; ID = 3001} | Where-Object  { $_.Message -Match "This is a test message"}

--- a/terraform/modules/windows-test-domain/scripts/WEC/generate_events.ps1
+++ b/terraform/modules/windows-test-domain/scripts/WEC/generate_events.ps1
@@ -1,6 +1,13 @@
 # Set up new source for application log
-New-EventLog -Source TestSource -LogName Application
+New-EventLog -Source WECTestApplicationSource -LogName Application
 # Send a test event through
-Write-EventLog -LogName "Application" -Source TestSource -EventID 3001 -EntryType Information -Message "This is a test message"
+Write-EventLog -LogName "Application" -Source WECTestApplicationSource   -EventID 3001 -EntryType Information -Message "This is a test message"
 # Check test event has been sent
 Get-WinEvent -FilterHashtable @{logname='Application'; ID = 3001} | Where-Object  { $_.Message -Match "This is a test message"}
+
+# Set up new source for system log
+New-EventLog -Source WECTestSystemSource -LogName System
+# Send a test event through
+Write-EventLog -LogName "System" -Source WECTestSystemSource -EventID 3001 -EntryType Information -Message "This is a test message"
+# Check test event has been sent
+Get-WinEvent -FilterHashtable @{logname='System'; ID = 3001} | Where-Object  { $_.Message -Match "This is a test message"}

--- a/terraform/modules/windows-test-domain/scripts/WEC/generate_events.ps1
+++ b/terraform/modules/windows-test-domain/scripts/WEC/generate_events.ps1
@@ -1,0 +1,6 @@
+# Set up new source for application log
+New-EventLog -Source TestSource -LogName Application
+# Send a test event through
+Write-EventLog -LogName "Application" -Source TestSource -EventID 3001 -EntryType Information -Message "This is a test message"
+# Check test event has been sent
+Get-WinEvent -FilterHashtable @{logname='Application'; ID = 3001} | Where-Object  { $_.Message -Match "This is a test message"}


### PR DESCRIPTION
This PR:

- creates two scripts to generate test events in both the DC and WEC instance, in the Application and System log groups
- this script sets a different source name per instance and log group so we can see where the logs are coming from

relates this issue: https://github.com/alphagov/cyber-security-splunk-apps/issues/643