### PR TITLE
Refactor terraform to pass in account ID of config bucket.

### DIFF
--- a/terraform/deployments/103495720024/module-windows-test-domain.tf
+++ b/terraform/deployments/103495720024/module-windows-test-domain.tf
@@ -9,6 +9,7 @@ module "windows_test_domain_module" {
   public_key_path       = var.public_key_path
   private_key_path      = var.private_key_path
   domain_name           = var.domain_name
+  splunk_config_account = var.splunk_config_account
   splunk_config_bucket  = var.splunk_config_bucket
   splunk_forwarder_name = var.splunk_forwarder_name
 }

--- a/terraform/deployments/103495720024/variables.tf
+++ b/terraform/deployments/103495720024/variables.tf
@@ -32,6 +32,13 @@ variable "domain_name" {
   type        = string
   default     = "cdio-windows-sandbox-staging.com"
 }
+
+variable "splunk_config_account" {
+  description = "AWS account ID for the target bucket for retrieving config."
+  type        = string
+  default     = "103495720024"
+}
+
 variable "splunk_config_bucket" {
   description = "Name of the target bucket for retrieving config."
   type        = string

--- a/terraform/deployments/373632528784/module-windows-test-domain.tf
+++ b/terraform/deployments/373632528784/module-windows-test-domain.tf
@@ -9,6 +9,7 @@ module "windows_test_domain_module" {
   public_key_path       = var.public_key_path
   private_key_path      = var.private_key_path
   domain_name           = var.domain_name
+  splunk_config_account = var.splunk_config_account
   splunk_config_bucket  = var.splunk_config_bucket
   splunk_forwarder_name = var.splunk_forwarder_name
 }

--- a/terraform/deployments/373632528784/variables.tf
+++ b/terraform/deployments/373632528784/variables.tf
@@ -32,6 +32,13 @@ variable "domain_name" {
   type        = string
   default     = "cdio-windows-sandbox-staging.com"
 }
+
+variable "splunk_config_account" {
+  description = "AWS account ID for the target bucket for retrieving config."
+  type        = string
+  default     = "103495720024"
+}
+
 variable "splunk_config_bucket" {
   description = "Name of the target bucket for retrieving config."
   type        = string

--- a/terraform/modules/windows-test-domain/locals.tf
+++ b/terraform/modules/windows-test-domain/locals.tf
@@ -14,7 +14,7 @@ locals {
     "ENVIRONMENT" : var.environment,
     "FORWARDER" : var.splunk_forwarder_name,
     "BUCKET_NAME" : var.splunk_config_bucket,
-    "AWS_ACCOUNT" : data.aws_caller_identity.current.account_id,
+    "AWS_ACCOUNT" : var.splunk_config_account,
     "SPLUNK_PASSWORD" : random_password.splunk_admin_password.result,
     "DOMAIN_PASSWORD" : random_password.domain_admin_password.result,
     "DOMAIN" : var.domain_name

--- a/terraform/modules/windows-test-domain/variables.tf
+++ b/terraform/modules/windows-test-domain/variables.tf
@@ -38,6 +38,11 @@ variable "external_dns_servers" {
   default     = ["8.8.8.8"]
 }
 
+variable "splunk_config_account" {
+  description = "AWS account ID for the target bucket for retrieving config."
+  type        = string
+}
+
 variable "splunk_config_bucket" {
   description = "Name of the target bucket for retriving config."
   type        = string


### PR DESCRIPTION
For the 3637 account this points back to the staging 1034 account and makes a cross-account assume to access S3.