### PR TITLE
Generate events last to ensure they don't timeout before smoke tests

### DIFF
--- a/terraform/modules/windows-test-domain/ec2-wec.tf
+++ b/terraform/modules/windows-test-domain/ec2-wec.tf
@@ -39,7 +39,6 @@ resource "aws_instance" "wec" {
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\registry_system_enableula_sacl.ps1",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\registry_terminal_server_sacl.ps1",
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WinRM\\set_dns_resolvers.ps1",
-      "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\generate_events.ps1",
       "powershell Restart-Computer -Force"
     ]
 
@@ -137,6 +136,28 @@ resource "null_resource" "wec_forward_to_splunk" {
       "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\install_packages.ps1",
       "powershell C:\\Set-AuditRule\\Set-AuditRule.ps1",
       "powershell Restart-Computer -Force"
+    ]
+
+  }
+
+}
+
+
+resource "null_resource" "wec_generate_events" {
+  depends_on = [null_resource.wec_forward_to_splunk]
+  provisioner "remote-exec" {
+    connection {
+      host     = coalesce(aws_instance.wec.public_ip, aws_instance.wec.private_ip)
+      type     = "winrm"
+      user     = "Administrator"
+      password = rsadecrypt(aws_instance.wec.password_data, file(var.private_key_path))
+      https    = true
+      insecure = true
+      port     = 5986
+    }
+    inline = [
+      "powershell Set-ExecutionPolicy Unrestricted -Force",
+      "powershell C:\\alphagov-windows-sandbox\\terraform\\modules\\windows-test-domain\\scripts\\WEC\\generate_events.ps1",
     ]
 
   }


### PR DESCRIPTION
Reorder the remote-execs so that the events are generated into the event logs after both the DC and WEC instances have been fully provisioned. This should mean there's less chance of the events being outside the window the smoke tests are looking for. 