### PR TITLE
increase the version of the windows server

### DIFF
--- a/terraform/modules/windows-test-domain/data.tf
+++ b/terraform/modules/windows-test-domain/data.tf
@@ -6,9 +6,10 @@ data "aws_region" "current" {}
 
 data "aws_ami" "windows_server_2016_base" {
   owners = ["amazon"]
+  most_recent = true
   filter {
     name   = "name"
-    values = ["Windows_Server-2016-English-Core-Base-2021.06.09"]
+    values = ["Windows_Server-2016-English-Core-Base-2021.*"]
   }
 }
 

--- a/terraform/modules/windows-test-domain/data.tf
+++ b/terraform/modules/windows-test-domain/data.tf
@@ -8,7 +8,7 @@ data "aws_ami" "windows_server_2016_base" {
   owners = ["amazon"]
   filter {
     name   = "name"
-    values = ["Windows_Server-2016-English-Core-Base-2021.04.14"]
+    values = ["Windows_Server-2016-English-Core-Base-2021.06.09"]
   }
 }
 


### PR DESCRIPTION
increase the version of the windows server to `Windows_Server-2016-English-Core-Base-2021.06.09`, as the previous AMI `Windows_Server-2016-English-Core-Base-2021.04.14` has been removed